### PR TITLE
Docs/add missing typedoc plugins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to @phun-ky/speccer
+# Contributing to **SPECCER**
 
 First off, thanks for taking the time to contribute! ❤️
 
@@ -13,7 +13,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 
 ## Table of Contents
 
-- [Contributing to @phun-ky/speccer](#contributing-to-phun-kyspeccer)
+- [Contributing to **SPECCER**](#contributing-to-speccer)
   - [Table of Contents](#table-of-contents)
   - [Code of Conduct](#code-of-conduct)
   - [I Have a Question](#i-have-a-question)
@@ -29,7 +29,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 ## Code of Conduct
 
 This project and everyone participating in it is governed by the
-[@phun-ky/speccer Code of Conduct](https://github.com/phun-ky/speccer/blob/master/CODE_OF_CONDUCT.md).
+[**SPECCER** Code of Conduct](https://github.com/phun-ky/speccer/blob/master/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
 to <code-of-conduct@phun-ky.net>.
 
@@ -108,7 +108,7 @@ Once it's filed:
 
 ### Suggesting Enhancements
 
-This section guides you through submitting an enhancement suggestion for @phun-ky/speccer, **including completely new features and minor improvements to existing functionality**. Following these guidelines will help maintainers and the community to understand your suggestion and find related suggestions.
+This section guides you through submitting an enhancement suggestion for **SPECCER**, **including completely new features and minor improvements to existing functionality**. Following these guidelines will help maintainers and the community to understand your suggestion and find related suggestions.
 
 #### Before Submitting an Enhancement
 
@@ -125,7 +125,7 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/phun-k
 - Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
 - **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
 - You may want to **include screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux. <!-- this should only be included if the project has a GUI -->
-- **Explain why this enhancement would be useful** to most @phun-ky/speccer users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
+- **Explain why this enhancement would be useful** to most **SPECCER** users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
 
 <!-- You might want to create an issue template for enhancement suggestions that can be used as a guide and that defines the structure of the information to be included. If you do so, reference it here in the description. -->
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ In your component examples, use the following attribute. Remember to use the `da
 ```html
 <div data-speccer="pin-area">
   <div
-    data-speccer="pin [bracket|enclose][curly] [left|right|top|bottom]"
+    data-speccer="pin [bracket [curly] |enclose] [left|right|top|bottom]"
     class="..."
   ></div>
 </div>

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ speccer();
 
 #### Lazy loading
 
-If you're importing speccer instead of with a script tag, [you can use the following approach](https://codepen.io/phun-ky/pen/VwRRLyY) to apply lazy loading:
+If you're importing **SPECCER** instead of with a script tag, [you can use the following approach](https://codepen.io/phun-ky/pen/VwRRLyY) to apply lazy loading:
 
 ```javascript
 import { pin } from "https://esm.sh/@phun-ky/speccer";
@@ -139,7 +139,7 @@ And then follow the steps below to display the specifications you want :)
 
 #### Advanced usage
 
-If you want to control speccer a bit more, you have some options. Apply one of these attributes to the script element for different types of initialization:
+If you want to control **SPECCER** a bit more, you have some options. Apply one of these attributes to the script element for different types of initialization:
 
 ```html
 <script src="../speccer.js" data-<manual|instant|dom|lazy></script>
@@ -440,7 +440,7 @@ In your component examples, use the following attribute.
 
 ### A11y notation
 
-With speccer, you can also display accessibility notation, like [Accessibility Bluelines](https://dribbble.com/shots/6269661-Accessibility-Bluelines?utm_source=Clipboard_Shot&utm_campaign=jeremyelder&utm_content=Accessibility%20Bluelines&utm_medium=Social_Share&utm_source=Clipboard_Shot&utm_campaign=jeremyelder&utm_content=Accessibility%20Bluelines&utm_medium=Social_Share):
+With **SPECCER**, you can also display accessibility notation, like [Accessibility Bluelines](https://dribbble.com/shots/6269661-Accessibility-Bluelines?utm_source=Clipboard_Shot&utm_campaign=jeremyelder&utm_content=Accessibility%20Bluelines&utm_medium=Social_Share&utm_source=Clipboard_Shot&utm_campaign=jeremyelder&utm_content=Accessibility%20Bluelines&utm_medium=Social_Share):
 
 Prior art: [Jeremy Elder](https://twitter.com/JeremyElder)
 

--- a/api/README.md
+++ b/api/README.md
@@ -8,7 +8,7 @@
 
 ---
 
-> Last updated 2024-08-20T06:28:48.100Z
+> Last updated 2024-08-20T06:35:08.838Z
 
 ## Modules
 

--- a/api/config/browser.md
+++ b/api/config/browser.md
@@ -6,7 +6,7 @@
 
 # config/browser
 
-> Last updated 2024-08-20T06:28:48.103Z
+> Last updated 2024-08-20T06:35:08.839Z
 
 Contains the helper functions to activate SPECCER via a script tag, based on attributes:
 

--- a/api/features/a11y.md
+++ b/api/features/a11y.md
@@ -6,7 +6,7 @@
 
 # features/a11y
 
-> Last updated 2024-08-20T06:28:48.106Z
+> Last updated 2024-08-20T06:35:08.842Z
 
 ## Functions
 
@@ -28,7 +28,7 @@ Creates an HTML element based on the specified type. \*
 
 #### Returns
 
-`HTMLElement`
+[`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)
 
 The created HTML element.
 
@@ -59,15 +59,15 @@ Adds an accessibility element to the document body based on the target element a
 
 #### Parameters
 
-| Parameter  | Type          | Description                                               |
-| ---------- | ------------- | --------------------------------------------------------- |
-| `targetEl` | `HTMLElement` | Target HTML element.                                      |
-| `content`? | `unknown`     | Content to be added to the accessibility element.         |
-| `type`?    | `string`      | Type of accessibility element ('tabstops' or 'landmark'). |
+| Parameter  | Type                                                                    | Description                                               |
+| ---------- | ----------------------------------------------------------------------- | --------------------------------------------------------- |
+| `targetEl` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | Target HTML element.                                      |
+| `content`? | `unknown`                                                               | Content to be added to the accessibility element.         |
+| `type`?    | `string`                                                                | Type of accessibility element ('tabstops' or 'landmark'). |
 
 #### Returns
 
-`Promise`\<`void`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`>
 
 A Promise resolving when the operation is complete.
 
@@ -123,14 +123,14 @@ Adds a shortcut element to the document body based on the provided HTML element 
 
 #### Parameters
 
-| Parameter        | Type          | Description                      |
-| ---------------- | ------------- | -------------------------------- |
-| `el`             | `HTMLElement` | Target HTML element.             |
-| `shortcutString` | `string`      | Shortcut string to be displayed. |
+| Parameter        | Type                                                                    | Description                      |
+| ---------------- | ----------------------------------------------------------------------- | -------------------------------- |
+| `el`             | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | Target HTML element.             |
+| `shortcutString` | `string`                                                                | Shortcut string to be displayed. |
 
 #### Returns
 
-`Promise`\<`void`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`>
 
 A Promise resolving when the operation is complete.
 

--- a/api/features/a11y/constants.md
+++ b/api/features/a11y/constants.md
@@ -6,7 +6,7 @@
 
 # features/a11y/constants
 
-> Last updated 2024-08-20T06:28:48.108Z
+> Last updated 2024-08-20T06:35:08.843Z
 
 ## Variables
 

--- a/api/features/a11y/utils/styles.md
+++ b/api/features/a11y/utils/styles.md
@@ -6,7 +6,7 @@
 
 # features/a11y/utils/styles
 
-> Last updated 2024-08-20T06:28:48.110Z
+> Last updated 2024-08-20T06:35:08.844Z
 
 ## Functions
 
@@ -24,15 +24,15 @@ Calculates and returns the styles for an accessibility element based on its type
 
 #### Parameters
 
-| Parameter       | Type          | Description                                                                                   |
-| --------------- | ------------- | --------------------------------------------------------------------------------------------- |
-| `type`          | `string`      | Type of the accessibility element ('tabstops', 'landmark', 'region', 'shortcut', or default). |
-| `targetElement` | `HTMLElement` | Target HTML element.                                                                          |
-| `a11yElement`   | `HTMLElement` | Accessibility HTML element to be styled.                                                      |
+| Parameter       | Type                                                                    | Description                                                                                   |
+| --------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `type`          | `string`                                                                | Type of the accessibility element ('tabstops', 'landmark', 'region', 'shortcut', or default). |
+| `targetElement` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | Target HTML element.                                                                          |
+| `a11yElement`   | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | Accessibility HTML element to be styled.                                                      |
 
 #### Returns
 
-`Promise`\<[`SpeccerStylesReturnType`](../../../types/styles.md#speccerstylesreturntype)>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`SpeccerStylesReturnType`](../../../types/styles.md#speccerstylesreturntype)>
 
 A Promise resolving with the calculated styles.
 

--- a/api/features/grid.md
+++ b/api/features/grid.md
@@ -6,7 +6,7 @@
 
 # features/grid
 
-> Last updated 2024-08-20T06:28:48.110Z
+> Last updated 2024-08-20T06:35:08.844Z
 
 ## Functions
 
@@ -20,14 +20,14 @@ Creates a visual grid overlay for a given target element.
 
 #### Parameters
 
-| Parameter       | Type                  | Description                                        |
-| --------------- | --------------------- | -------------------------------------------------- |
-| `targetElement` | `HTMLElement`         | The target element to create the grid overlay for. |
-| `styles`        | `CSSStyleDeclaration` | The computed styles of the target element.         |
+| Parameter       | Type                                                                                    | Description                                        |
+| --------------- | --------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `targetElement` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)                 | The target element to create the grid overlay for. |
+| `styles`        | [`CSSStyleDeclaration`](https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration) | The computed styles of the target element.         |
 
 #### Returns
 
-`Promise`\<`HTMLDivElement`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`HTMLDivElement`](https://developer.mozilla.org/docs/Web/API/HTMLDivElement)>
 
 The created grid container element.
 
@@ -62,13 +62,13 @@ Adds a visual grid overlay to the target element if it has the appropriate data 
 
 #### Parameters
 
-| Parameter       | Type          | Description                                    |
-| --------------- | ------------- | ---------------------------------------------- |
-| `targetElement` | `HTMLElement` | The target element to add the grid overlay to. |
+| Parameter       | Type                                                                    | Description                                    |
+| --------------- | ----------------------------------------------------------------------- | ---------------------------------------------- |
+| `targetElement` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The target element to add the grid overlay to. |
 
 #### Returns
 
-`Promise`\<`void`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`>
 
 A promise that resolves once the overlay has been added.
 

--- a/api/features/mark.md
+++ b/api/features/mark.md
@@ -6,7 +6,7 @@
 
 # features/mark
 
-> Last updated 2024-08-20T06:28:48.111Z
+> Last updated 2024-08-20T06:35:08.845Z
 
 ## Functions
 
@@ -26,7 +26,7 @@ Create a marker element with an optional element type.
 
 #### Returns
 
-`HTMLElement`
+[`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)
 
 - The created marker element.
 
@@ -55,13 +55,13 @@ Create a marker element and add it to the body with styles matching a specified 
 
 #### Parameters
 
-| Parameter       | Type          | Description                              |
-| --------------- | ------------- | ---------------------------------------- |
-| `targetElement` | `HTMLElement` | The target element to match styles with. |
+| Parameter       | Type                                                                    | Description                              |
+| --------------- | ----------------------------------------------------------------------- | ---------------------------------------- |
+| `targetElement` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The target element to match styles with. |
 
 #### Returns
 
-`Promise`\<`void`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`>
 
 - A promise that resolves after creating and styling the marker element.
 

--- a/api/features/measure.md
+++ b/api/features/measure.md
@@ -6,7 +6,7 @@
 
 # features/measure
 
-> Last updated 2024-08-20T06:28:48.112Z
+> Last updated 2024-08-20T06:35:08.845Z
 
 ## Functions
 
@@ -28,7 +28,7 @@ Create a measurement element with optional text, area, and element type.
 
 #### Returns
 
-`HTMLElement`
+[`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)
 
 - The created measurement element.
 
@@ -57,13 +57,13 @@ Create a measurement element and add it to the body with styles matching a speci
 
 #### Parameters
 
-| Parameter       | Type          | Description                              |
-| --------------- | ------------- | ---------------------------------------- |
-| `targetElement` | `HTMLElement` | The target element to match styles with. |
+| Parameter       | Type                                                                    | Description                              |
+| --------------- | ----------------------------------------------------------------------- | ---------------------------------------- |
+| `targetElement` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The target element to match styles with. |
 
 #### Returns
 
-`Promise`\<`void`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`>
 
 - A promise that resolves after creating and styling the measurement element.
 

--- a/api/features/pin.md
+++ b/api/features/pin.md
@@ -6,7 +6,7 @@
 
 # features/pin
 
-> Last updated 2024-08-20T06:28:48.112Z
+> Last updated 2024-08-20T06:35:08.846Z
 
 This feature highlights the anatomy of an element.
 
@@ -28,7 +28,7 @@ In your component examples, use the following attribute. Remember to use the `da
 ```html
 <div data-speccer="pin-area">
   <div
-    data-speccer="pin [bracket|enclose][curly] [left|right|top|bottom]"
+    data-speccer="pin [bracket [curly] |enclose] [left|right|top|bottom]"
     class="..."
   ></div>
 </div>
@@ -56,13 +56,13 @@ Create pinned elements based on the section element and its data-speccer attribu
 
 #### Parameters
 
-| Parameter        | Type          | Description                                     |
-| ---------------- | ------------- | ----------------------------------------------- |
-| `sectionElement` | `HTMLElement` | The section element containing pinned elements. |
+| Parameter        | Type                                                                    | Description                                     |
+| ---------------- | ----------------------------------------------------------------------- | ----------------------------------------------- |
+| `sectionElement` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The section element containing pinned elements. |
 
 #### Returns
 
-`Promise`\<`void`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`>
 
 - A promise that resolves after creating pinned elements.
 

--- a/api/features/pin/utils/create-pin-element.md
+++ b/api/features/pin/utils/create-pin-element.md
@@ -6,7 +6,7 @@
 
 # features/pin/utils/create-pin-element
 
-> Last updated 2024-08-20T06:28:48.113Z
+> Last updated 2024-08-20T06:35:08.846Z
 
 ## Functions
 
@@ -29,7 +29,7 @@ Create a pin element with optional text content, area description, and element t
 
 #### Returns
 
-`HTMLElement`
+[`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)
 
 - The created pin element.
 

--- a/api/features/pin/utils/get-character-to-use.md
+++ b/api/features/pin/utils/get-character-to-use.md
@@ -6,7 +6,7 @@
 
 # features/pin/utils/get-character-to-use
 
-> Last updated 2024-08-20T06:28:48.114Z
+> Last updated 2024-08-20T06:35:08.847Z
 
 ## Functions
 

--- a/api/features/pin/utils/pin-element.md
+++ b/api/features/pin/utils/pin-element.md
@@ -6,7 +6,7 @@
 
 # features/pin/utils/pin-element
 
-> Last updated 2024-08-20T06:28:48.114Z
+> Last updated 2024-08-20T06:35:08.847Z
 
 ## Functions
 
@@ -28,16 +28,16 @@ of the target element. It handles different styles, such as curly brackets or li
 
 #### Parameters
 
-| Parameter       | Type          | Default value | Description                                                                        |
-| --------------- | ------------- | ------------- | ---------------------------------------------------------------------------------- |
-| `targetElement` | `HTMLElement` | `undefined`   | The target element that contains the pin data.                                     |
-| `symbol`        | `string`      | `undefined`   | The symbol to use.                                                                 |
-| `parentElement` | `HTMLElement` | `undefined`   | The parent element                                                                 |
-| `areas`?        | `string`      | `''`          | Optional areas to use if not \[data-speccer] is set as an attribute on the element |
+| Parameter       | Type                                                                    | Default value | Description                                                                        |
+| --------------- | ----------------------------------------------------------------------- | ------------- | ---------------------------------------------------------------------------------- |
+| `targetElement` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | `undefined`   | The target element that contains the pin data.                                     |
+| `symbol`        | `string`                                                                | `undefined`   | The symbol to use.                                                                 |
+| `parentElement` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | `undefined`   | The parent element                                                                 |
+| `areas`?        | `string`                                                                | `''`          | Optional areas to use if not \[data-speccer] is set as an attribute on the element |
 
 #### Returns
 
-`Promise`\<`string` | `void`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`string` | `void`>
 
 A promise that resolves to the id of the pin element when the process is completed, or `void` if required input is invalid.
 

--- a/api/features/pin/utils/styles.md
+++ b/api/features/pin/utils/styles.md
@@ -6,7 +6,7 @@
 
 # features/pin/utils/styles
 
-> Last updated 2024-08-20T06:28:48.115Z
+> Last updated 2024-08-20T06:35:08.847Z
 
 ## Functions
 
@@ -29,14 +29,14 @@ Get styles for pin elements based on the specified area and options.
 | Parameter       | Type                                                                    | Description              |
 | --------------- | ----------------------------------------------------------------------- | ------------------------ |
 | `area`          | `string`                                                                | The area description.    |
-| `targetElement` | `HTMLElement`                                                           | The target element.      |
-| `pinElement`    | `HTMLElement`                                                           | The pin element.         |
-| `parentElement` | `HTMLElement`                                                           | The parent element.      |
+| `targetElement` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The target element.      |
+| `pinElement`    | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The pin element.         |
+| `parentElement` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The parent element.      |
 | `options`?      | [`PinStylesOptionsType`](../../../types/bezier.md#pinstylesoptionstype) | Optional styles options. |
 
 #### Returns
 
-`Promise`\<[`SpeccerStylesReturnType`](../../../types/styles.md#speccerstylesreturntype)>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`SpeccerStylesReturnType`](../../../types/styles.md#speccerstylesreturntype)>
 
 - The computed styles.
 

--- a/api/features/spacing.md
+++ b/api/features/spacing.md
@@ -6,7 +6,7 @@
 
 # features/spacing
 
-> Last updated 2024-08-20T06:28:48.115Z
+> Last updated 2024-08-20T06:35:08.847Z
 
 ## Functions
 
@@ -27,7 +27,7 @@ Create a spacing element with optional text content.
 
 #### Returns
 
-`HTMLElement`
+[`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)
 
 - The created spacing element.
 
@@ -56,13 +56,13 @@ Create and position spacing elements based on the target element's computed spac
 
 #### Parameters
 
-| Parameter       | Type          | Description                                        |
-| --------------- | ------------- | -------------------------------------------------- |
-| `targetElement` | `HTMLElement` | The target element to create spacing elements for. |
+| Parameter       | Type                                                                    | Description                                        |
+| --------------- | ----------------------------------------------------------------------- | -------------------------------------------------- |
+| `targetElement` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The target element to create spacing elements for. |
 
 #### Returns
 
-`Promise`\<`void`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`>
 
 - A promise that resolves after creating and positioning the spacing elements.
 

--- a/api/features/spacing/utils/position.md
+++ b/api/features/spacing/utils/position.md
@@ -6,7 +6,7 @@
 
 # features/spacing/utils/position
 
-> Last updated 2024-08-20T06:28:48.115Z
+> Last updated 2024-08-20T06:35:08.848Z
 
 ## Functions
 
@@ -25,16 +25,16 @@ Set the position and dimensions of a spacing element relative to a target elemen
 
 #### Parameters
 
-| Parameter        | Type          | Description                                                      |
-| ---------------- | ------------- | ---------------------------------------------------------------- |
-| `property`       | `string`      | The CSS property to set (e.g., 'marginTop', 'marginLeft', etc.). |
-| `value`          | `number`      | The value of the CSS property.                                   |
-| `spacingElement` | `HTMLElement` | The spacing element.                                             |
-| `targetElement`  | `HTMLElement` | The target element.                                              |
+| Parameter        | Type                                                                    | Description                                                      |
+| ---------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `property`       | `string`                                                                | The CSS property to set (e.g., 'marginTop', 'marginLeft', etc.). |
+| `value`          | `number`                                                                | The value of the CSS property.                                   |
+| `spacingElement` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The spacing element.                                             |
+| `targetElement`  | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The target element.                                              |
 
 #### Returns
 
-`Promise`\<`void`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`>
 
 - A promise that resolves after setting the position and dimensions.
 

--- a/api/features/typography.md
+++ b/api/features/typography.md
@@ -6,7 +6,7 @@
 
 # features/typography
 
-> Last updated 2024-08-20T06:28:48.116Z
+> Last updated 2024-08-20T06:35:08.848Z
 
 ## Functions
 
@@ -27,7 +27,7 @@ Create a DOM element with provided HTML and optional CSS class names.
 
 #### Returns
 
-`HTMLElement`
+[`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)
 
 - The created DOM element.
 
@@ -58,13 +58,13 @@ Create a specced typography element for a given target element.
 
 #### Parameters
 
-| Parameter       | Type          | Description                                 |
-| --------------- | ------------- | ------------------------------------------- |
-| `targetElement` | `HTMLElement` | The target element to specc typography for. |
+| Parameter       | Type                                                                    | Description                                 |
+| --------------- | ----------------------------------------------------------------------- | ------------------------------------------- |
+| `targetElement` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The target element to specc typography for. |
 
 #### Returns
 
-`Promise`\<`void`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`>
 
 - A promise that resolves once typography element is created and positioned.
 

--- a/api/features/typography/utils/position.md
+++ b/api/features/typography/utils/position.md
@@ -6,7 +6,7 @@
 
 # features/typography/utils/position
 
-> Last updated 2024-08-20T06:28:48.116Z
+> Last updated 2024-08-20T06:35:08.848Z
 
 ## Functions
 
@@ -27,15 +27,15 @@ Calculate the position for the speccer element relative to the target element.
 
 #### Parameters
 
-| Parameter        | Type               | Description                           |
-| ---------------- | ------------------ | ------------------------------------- |
-| `area`           | `null` \| `string` | The area information for positioning. |
-| `targetElement`  | `HTMLElement`      | The target element.                   |
-| `speccerElement` | `HTMLElement`      | The speccer element to position.      |
+| Parameter        | Type                                                                    | Description                           |
+| ---------------- | ----------------------------------------------------------------------- | ------------------------------------- |
+| `area`           | `null` \| `string`                                                      | The area information for positioning. |
+| `targetElement`  | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The target element.                   |
+| `speccerElement` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The speccer element to position.      |
 
 #### Returns
 
-`Promise`\<\{
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<\{
 `left`: `string`;
 `top`: `string`;
 }>

--- a/api/features/typography/utils/template.md
+++ b/api/features/typography/utils/template.md
@@ -6,7 +6,7 @@
 
 # features/typography/utils/template
 
-> Last updated 2024-08-20T06:28:48.117Z
+> Last updated 2024-08-20T06:35:08.849Z
 
 ## Functions
 
@@ -20,14 +20,14 @@ Generate a HTML string for typography styles of a target element.
 
 #### Parameters
 
-| Parameter          | Type          | Default value | Description                                                 |
-| ------------------ | ------------- | ------------- | ----------------------------------------------------------- |
-| `targetElement`    | `HTMLElement` | `undefined`   | The target element for which to generate typography styles. |
-| `useHighlighting`? | `boolean`     | `false`       | If we should use highlighting markup                        |
+| Parameter          | Type                                                                    | Default value | Description                                                 |
+| ------------------ | ----------------------------------------------------------------------- | ------------- | ----------------------------------------------------------- |
+| `targetElement`    | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | `undefined`   | The target element for which to generate typography styles. |
+| `useHighlighting`? | `boolean`                                                               | `false`       | If we should use highlighting markup                        |
 
 #### Returns
 
-`Promise`\<`string`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`string`>
 
 - A promise that resolves with the HTML string.
 

--- a/api/main.md
+++ b/api/main.md
@@ -6,7 +6,7 @@
 
 # main
 
-> Last updated 2024-08-20T06:28:48.118Z
+> Last updated 2024-08-20T06:35:08.849Z
 
 ## Table of Contents
 
@@ -20,7 +20,7 @@
   - [spacing](#spacing)
   - [typography](#typography)
 - [Functions](#functions)
-  - [default()](#default)
+  - [speccer()](#speccer)
 
 ## Examples
 
@@ -65,7 +65,7 @@ const grid: {
 </td>
 <td>
 
-(`targetElement`, `styles`) => `Promise`\<`HTMLDivElement`>
+(`targetElement`, `styles`) => [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`HTMLDivElement`](https://developer.mozilla.org/docs/Web/API/HTMLDivElement)>
 
 </td>
 <td>
@@ -87,7 +87,7 @@ gridCreate
 </td>
 <td>
 
-(`targetElement`) => `Promise`\<`void`>
+(`targetElement`) => [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`>
 
 </td>
 <td>
@@ -135,7 +135,7 @@ const mark: {
 </td>
 <td>
 
-(`n`) => `HTMLElement`
+(`n`) => [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)
 
 </td>
 <td>
@@ -157,7 +157,7 @@ markCreate
 </td>
 <td>
 
-(`targetElement`) => `Promise`\<`void`>
+(`targetElement`) => [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`>
 
 </td>
 <td>
@@ -205,7 +205,7 @@ const measure: {
 </td>
 <td>
 
-(`text`, `area`, `tag`) => `HTMLElement`
+(`text`, `area`, `tag`) => [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)
 
 </td>
 <td>
@@ -227,7 +227,7 @@ measureCreate
 </td>
 <td>
 
-(`targetElement`) => `Promise`\<`void`>
+(`targetElement`) => [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`>
 
 </td>
 <td>
@@ -375,7 +375,7 @@ const pin: {
 </td>
 <td>
 
-(`textContent`, `area`, `id`, `n`) => `HTMLElement`
+(`textContent`, `area`, `id`, `n`) => [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)
 
 </td>
 <td>
@@ -392,7 +392,7 @@ const pin: {
 </td>
 <td>
 
-(`targetElement`, `symbol`, `parentElement`, `areas`?) => `Promise`\<`string` | `void`>
+(`targetElement`, `symbol`, `parentElement`, `areas`?) => [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`string` | `void`>
 
 </td>
 <td>
@@ -409,7 +409,7 @@ const pin: {
 </td>
 <td>
 
-(`sectionElement`) => `Promise`\<`void`>
+(`sectionElement`) => [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`>
 
 </td>
 <td>
@@ -452,7 +452,7 @@ const spacing: {
 </td>
 <td>
 
-(`text`, `tag`) => `HTMLElement`
+(`text`, `tag`) => [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)
 
 </td>
 <td>
@@ -474,7 +474,7 @@ spacingCreate
 </td>
 <td>
 
-(`targetElement`) => `Promise`\<`void`>
+(`targetElement`) => [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`>
 
 </td>
 <td>
@@ -522,7 +522,7 @@ const typography: {
 </td>
 <td>
 
-(`html`, `area`) => `HTMLElement`
+(`html`, `area`) => [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)
 
 </td>
 <td>
@@ -544,7 +544,7 @@ typographyCreate
 </td>
 <td>
 
-(`targetElement`) => `Promise`\<`void`>
+(`targetElement`) => [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`>
 
 </td>
 <td>
@@ -566,10 +566,10 @@ typographyElement
 
 ## Functions
 
-### default()
+### speccer()
 
 ```ts
-function default(): void
+function speccer(): void;
 ```
 
 #### Returns

--- a/api/types/bezier.md
+++ b/api/types/bezier.md
@@ -6,7 +6,7 @@
 
 # types/bezier
 
-> Last updated 2024-08-20T06:28:48.120Z
+> Last updated 2024-08-20T06:35:08.850Z
 
 ## Type Aliases
 

--- a/api/types/css.md
+++ b/api/types/css.md
@@ -6,7 +6,7 @@
 
 # types/css
 
-> Last updated 2024-08-20T06:28:48.121Z
+> Last updated 2024-08-20T06:35:08.851Z
 
 ## Type Aliases
 

--- a/api/types/debounce.md
+++ b/api/types/debounce.md
@@ -6,7 +6,7 @@
 
 # types/debounce
 
-> Last updated 2024-08-20T06:28:48.122Z
+> Last updated 2024-08-20T06:35:08.851Z
 
 ## Type Aliases
 

--- a/api/types/enums/area.md
+++ b/api/types/enums/area.md
@@ -6,7 +6,7 @@
 
 # types/enums/area
 
-> Last updated 2024-08-20T06:28:48.122Z
+> Last updated 2024-08-20T06:35:08.852Z
 
 ## Enumerations
 

--- a/api/types/interfaces/attributes.md
+++ b/api/types/interfaces/attributes.md
@@ -6,7 +6,7 @@
 
 # types/interfaces/attributes
 
-> Last updated 2024-08-20T06:28:48.123Z
+> Last updated 2024-08-20T06:35:08.852Z
 
 ## Interfaces
 

--- a/api/types/interfaces/classnames.md
+++ b/api/types/interfaces/classnames.md
@@ -6,7 +6,7 @@
 
 # types/interfaces/classnames
 
-> Last updated 2024-08-20T06:28:48.123Z
+> Last updated 2024-08-20T06:35:08.852Z
 
 ## Type Aliases
 

--- a/api/types/interfaces/global.md
+++ b/api/types/interfaces/global.md
@@ -6,7 +6,7 @@
 
 # types/interfaces/global
 
-> Last updated 2024-08-20T06:28:48.123Z
+> Last updated 2024-08-20T06:35:08.853Z
 
 ## Interfaces
 

--- a/api/types/interfaces/position.md
+++ b/api/types/interfaces/position.md
@@ -6,7 +6,7 @@
 
 # types/interfaces/position
 
-> Last updated 2024-08-20T06:28:48.124Z
+> Last updated 2024-08-20T06:35:08.853Z
 
 ## Interfaces
 

--- a/api/types/position.md
+++ b/api/types/position.md
@@ -6,7 +6,7 @@
 
 # types/position
 
-> Last updated 2024-08-20T06:28:48.125Z
+> Last updated 2024-08-20T06:35:08.853Z
 
 ## Type Aliases
 

--- a/api/types/speccer.md
+++ b/api/types/speccer.md
@@ -6,7 +6,7 @@
 
 # types/speccer
 
-> Last updated 2024-08-20T06:28:48.125Z
+> Last updated 2024-08-20T06:35:08.854Z
 
 ## Type Aliases
 

--- a/api/types/styles.md
+++ b/api/types/styles.md
@@ -6,7 +6,7 @@
 
 # types/styles
 
-> Last updated 2024-08-20T06:28:48.125Z
+> Last updated 2024-08-20T06:35:08.854Z
 
 ## Type Aliases
 

--- a/api/types/xy.md
+++ b/api/types/xy.md
@@ -6,7 +6,7 @@
 
 # types/xy
 
-> Last updated 2024-08-20T06:28:48.126Z
+> Last updated 2024-08-20T06:35:08.854Z
 
 ## Interfaces
 

--- a/api/utils/angle.md
+++ b/api/utils/angle.md
@@ -6,7 +6,7 @@
 
 # utils/angle
 
-> Last updated 2024-08-20T06:28:48.126Z
+> Last updated 2024-08-20T06:35:08.854Z
 
 ## Functions
 

--- a/api/utils/area.md
+++ b/api/utils/area.md
@@ -6,7 +6,7 @@
 
 # utils/area
 
-> Last updated 2024-08-20T06:28:48.126Z
+> Last updated 2024-08-20T06:35:08.854Z
 
 ## Functions
 
@@ -313,10 +313,10 @@ Checks if the provided areaString contains 'grid'.
 
 #### Parameters
 
-| Parameter    | Type                  | Description                  |
-| ------------ | --------------------- | ---------------------------- |
-| `areaString` | `null` \| `string`    | The string containing areas. |
-| `styles`     | `CSSStyleDeclaration` | -                            |
+| Parameter    | Type                                                                                    | Description                  |
+| ------------ | --------------------------------------------------------------------------------------- | ---------------------------- |
+| `areaString` | `null` \| `string`                                                                      | The string containing areas. |
+| `styles`     | [`CSSStyleDeclaration`](https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration) | -                            |
 
 #### Returns
 

--- a/api/utils/attributes.md
+++ b/api/utils/attributes.md
@@ -6,7 +6,7 @@
 
 # utils/attributes
 
-> Last updated 2024-08-20T06:28:48.128Z
+> Last updated 2024-08-20T06:35:08.855Z
 
 ## Functions
 
@@ -20,10 +20,10 @@ Removes attributes from an HTML element.
 
 #### Parameters
 
-| Parameter | Type          | Description                                      |
-| --------- | ------------- | ------------------------------------------------ |
-| `el`      | `HTMLElement` | The HTML element to remove attributes from.      |
-| `attrs`?  | `string`\[]   | The attributes to remove as a key-value mapping. |
+| Parameter | Type                                                                    | Description                                      |
+| --------- | ----------------------------------------------------------------------- | ------------------------------------------------ |
+| `el`      | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The HTML element to remove attributes from.      |
+| `attrs`?  | `string`\[]                                                             | The attributes to remove as a key-value mapping. |
 
 #### Returns
 
@@ -54,7 +54,7 @@ Sets attributes on an HTML element.
 
 | Parameter | Type                                                                                 | Description                                   |
 | --------- | ------------------------------------------------------------------------------------ | --------------------------------------------- |
-| `el`      | `HTMLElement`                                                                        | The HTML element to set attributes on.        |
+| `el`      | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)              | The HTML element to set attributes on.        |
 | `attrs`?  | [`AttributesMapInterface`](../types/interfaces/attributes.md#attributesmapinterface) | The attributes to set as a key-value mapping. |
 
 #### Returns

--- a/api/utils/bezier.md
+++ b/api/utils/bezier.md
@@ -6,7 +6,7 @@
 
 # utils/bezier
 
-> Last updated 2024-08-20T06:28:48.128Z
+> Last updated 2024-08-20T06:35:08.855Z
 
 ## Functions
 
@@ -112,13 +112,13 @@ Generates an SVG path for a curved line between two HTML elements.
 
 | Parameter | Type                                                                          | Description                              |
 | --------- | ----------------------------------------------------------------------------- | ---------------------------------------- |
-| `startEl` | `HTMLElement`                                                                 | The starting HTML element.               |
-| `stopEl`  | `HTMLElement`                                                                 | The ending HTML element.                 |
+| `startEl` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)       | The starting HTML element.               |
+| `stopEl`  | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)       | The ending HTML element.                 |
 | `options` | [`CurlyBezierPathOptionsType`](../types/bezier.md#curlybezierpathoptionstype) | Options for controlling the curved line. |
 
 #### Returns
 
-`Promise`\<`string`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`string`>
 
 The SVG path string for the curved line.
 
@@ -245,15 +245,15 @@ Generates an SVG path for a straight line between two HTML elements.
 
 #### Parameters
 
-| Parameter | Type                                                                | Description                                |
-| --------- | ------------------------------------------------------------------- | ------------------------------------------ |
-| `startEl` | `HTMLElement`                                                       | The starting HTML element.                 |
-| `stopEl`  | `HTMLElement`                                                       | The ending HTML element.                   |
-| `options` | [`BezierPathOptionsType`](../types/bezier.md#bezierpathoptionstype) | Options for controlling the straight line. |
+| Parameter | Type                                                                    | Description                                |
+| --------- | ----------------------------------------------------------------------- | ------------------------------------------ |
+| `startEl` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The starting HTML element.                 |
+| `stopEl`  | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The ending HTML element.                   |
+| `options` | [`BezierPathOptionsType`](../types/bezier.md#bezierpathoptionstype)     | Options for controlling the straight line. |
 
 #### Returns
 
-`Promise`\<`string`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`string`>
 
 The SVG path string for the straight line.
 

--- a/api/utils/camel-case.md
+++ b/api/utils/camel-case.md
@@ -6,7 +6,7 @@
 
 # utils/camel-case
 
-> Last updated 2024-08-20T06:28:48.130Z
+> Last updated 2024-08-20T06:35:08.856Z
 
 ## Functions
 

--- a/api/utils/cardinal.md
+++ b/api/utils/cardinal.md
@@ -6,7 +6,7 @@
 
 # utils/cardinal
 
-> Last updated 2024-08-20T06:28:48.130Z
+> Last updated 2024-08-20T06:35:08.856Z
 
 ## Functions
 

--- a/api/utils/classes/DrawCircle.md
+++ b/api/utils/classes/DrawCircle.md
@@ -6,7 +6,7 @@
 
 # utils/classes/DrawCircle
 
-> Last updated 2024-08-20T06:28:48.130Z
+> Last updated 2024-08-20T06:35:08.857Z
 
 ## Classes
 
@@ -29,11 +29,11 @@ Creates a new DrawCircle instance.
 
 ###### Parameters
 
-| Parameter | Type          | Description                              |
-| --------- | ------------- | ---------------------------------------- |
-| `el`      | `HTMLElement` | The element used to position the circle. |
-| `radius`  | `number`      | The radius of the circle                 |
-| `areas`   | `string`      | The areas used to identify position      |
+| Parameter | Type                                                                    | Description                              |
+| --------- | ----------------------------------------------------------------------- | ---------------------------------------- |
+| `el`      | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The element used to position the circle. |
+| `radius`  | `number`                                                                | The radius of the circle                 |
+| `areas`   | `string`                                                                | The areas used to identify position      |
 
 ###### Returns
 
@@ -45,12 +45,12 @@ Creates a new DrawCircle instance.
 
 #### Properties
 
-| Property | Type               | Defined in                                                                                                         |
-| -------- | ------------------ | ------------------------------------------------------------------------------------------------------------------ |
-| `areas`  | `string`           | [utils/classes/DrawCircle.ts:14](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawCircle.ts#L14) |
-| `circle` | `SVGCircleElement` | [utils/classes/DrawCircle.ts:12](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawCircle.ts#L12) |
-| `el`     | `HTMLElement`      | [utils/classes/DrawCircle.ts:11](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawCircle.ts#L11) |
-| `radius` | `number`           | [utils/classes/DrawCircle.ts:13](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawCircle.ts#L13) |
+| Property | Type                                                                              | Defined in                                                                                                         |
+| -------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `areas`  | `string`                                                                          | [utils/classes/DrawCircle.ts:14](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawCircle.ts#L14) |
+| `circle` | [`SVGCircleElement`](https://developer.mozilla.org/docs/Web/API/SVGCircleElement) | [utils/classes/DrawCircle.ts:12](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawCircle.ts#L12) |
+| `el`     | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)           | [utils/classes/DrawCircle.ts:11](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawCircle.ts#L11) |
+| `radius` | `number`                                                                          | [utils/classes/DrawCircle.ts:13](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawCircle.ts#L13) |
 
 #### Methods
 
@@ -64,7 +64,7 @@ Draws the circle based on the provided el and radius.
 
 ###### Returns
 
-`Promise`\<`void`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`>
 
 ###### Defined in
 

--- a/api/utils/classes/DrawSVGCurlyBracket.md
+++ b/api/utils/classes/DrawSVGCurlyBracket.md
@@ -6,7 +6,7 @@
 
 # utils/classes/DrawSVGCurlyBracket
 
-> Last updated 2024-08-20T06:28:48.131Z
+> Last updated 2024-08-20T06:35:08.858Z
 
 ## Classes
 
@@ -26,10 +26,10 @@ Creates a new DrawSVGCurlyBracket instance.
 
 ###### Parameters
 
-| Parameter      | Type          | Description                           |
-| -------------- | ------------- | ------------------------------------- |
-| `startElement` | `HTMLElement` | The starting element for the bracket. |
-| `stopElement`  | `HTMLElement` | The ending element for the bracket.   |
+| Parameter      | Type                                                                    | Description                           |
+| -------------- | ----------------------------------------------------------------------- | ------------------------------------- |
+| `startElement` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The starting element for the bracket. |
+| `stopElement`  | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The ending element for the bracket.   |
 
 ###### Returns
 
@@ -41,12 +41,12 @@ Creates a new DrawSVGCurlyBracket instance.
 
 #### Properties
 
-| Property            | Type             | Defined in                                                                                                                           |
-| ------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `firstPathElement`  | `SVGPathElement` | [utils/classes/DrawSVGCurlyBracket.ts:14](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawSVGCurlyBracket.ts#L14) |
-| `secondPathElement` | `SVGPathElement` | [utils/classes/DrawSVGCurlyBracket.ts:15](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawSVGCurlyBracket.ts#L15) |
-| `startElement`      | `HTMLElement`    | [utils/classes/DrawSVGCurlyBracket.ts:12](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawSVGCurlyBracket.ts#L12) |
-| `stopElement`       | `HTMLElement`    | [utils/classes/DrawSVGCurlyBracket.ts:13](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawSVGCurlyBracket.ts#L13) |
+| Property            | Type                                                                          | Defined in                                                                                                                           |
+| ------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `firstPathElement`  | [`SVGPathElement`](https://developer.mozilla.org/docs/Web/API/SVGPathElement) | [utils/classes/DrawSVGCurlyBracket.ts:14](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawSVGCurlyBracket.ts#L14) |
+| `secondPathElement` | [`SVGPathElement`](https://developer.mozilla.org/docs/Web/API/SVGPathElement) | [utils/classes/DrawSVGCurlyBracket.ts:15](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawSVGCurlyBracket.ts#L15) |
+| `startElement`      | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)       | [utils/classes/DrawSVGCurlyBracket.ts:12](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawSVGCurlyBracket.ts#L12) |
+| `stopElement`       | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)       | [utils/classes/DrawSVGCurlyBracket.ts:13](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawSVGCurlyBracket.ts#L13) |
 
 #### Methods
 
@@ -76,13 +76,13 @@ Draws the curly bracket based on the provided path.
 
 ###### Parameters
 
-| Parameter | Type             | Description                                     |
-| --------- | ---------------- | ----------------------------------------------- |
-| `path`    | `SVGPathElement` | The SVGPathElement to be used as the base path. |
+| Parameter | Type                                                                          | Description                                     |
+| --------- | ----------------------------------------------------------------------------- | ----------------------------------------------- |
+| `path`    | [`SVGPathElement`](https://developer.mozilla.org/docs/Web/API/SVGPathElement) | The SVGPathElement to be used as the base path. |
 
 ###### Returns
 
-`Promise`\<`void`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`>
 
 ###### Throws
 

--- a/api/utils/classes/DrawSVGLine.md
+++ b/api/utils/classes/DrawSVGLine.md
@@ -6,7 +6,7 @@
 
 # utils/classes/DrawSVGLine
 
-> Last updated 2024-08-20T06:28:48.131Z
+> Last updated 2024-08-20T06:35:08.858Z
 
 ## Classes
 
@@ -26,10 +26,10 @@ Creates a new DrawSVGLine instance.
 
 ###### Parameters
 
-| Parameter      | Type          | Description                        |
-| -------------- | ------------- | ---------------------------------- |
-| `startElement` | `HTMLElement` | The starting element for the line. |
-| `stopElement`  | `HTMLElement` | The ending element for the line.   |
+| Parameter      | Type                                                                    | Description                        |
+| -------------- | ----------------------------------------------------------------------- | ---------------------------------- |
+| `startElement` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The starting element for the line. |
+| `stopElement`  | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The ending element for the line.   |
 
 ###### Returns
 
@@ -41,11 +41,11 @@ Creates a new DrawSVGLine instance.
 
 #### Properties
 
-| Property       | Type             | Defined in                                                                                                           |
-| -------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `line`         | `SVGPathElement` | [utils/classes/DrawSVGLine.ts:14](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawSVGLine.ts#L14) |
-| `startElement` | `HTMLElement`    | [utils/classes/DrawSVGLine.ts:12](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawSVGLine.ts#L12) |
-| `stopElement`  | `HTMLElement`    | [utils/classes/DrawSVGLine.ts:13](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawSVGLine.ts#L13) |
+| Property       | Type                                                                          | Defined in                                                                                                           |
+| -------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `line`         | [`SVGPathElement`](https://developer.mozilla.org/docs/Web/API/SVGPathElement) | [utils/classes/DrawSVGLine.ts:14](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawSVGLine.ts#L14) |
+| `startElement` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)       | [utils/classes/DrawSVGLine.ts:12](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawSVGLine.ts#L12) |
+| `stopElement`  | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)       | [utils/classes/DrawSVGLine.ts:13](https://github.com/phun-ky/speccer/blob/main/src/utils/classes/DrawSVGLine.ts#L13) |
 
 #### Methods
 
@@ -75,13 +75,13 @@ Draws the line based on the provided path.
 
 ###### Parameters
 
-| Parameter | Type             | Description                                     |
-| --------- | ---------------- | ----------------------------------------------- |
-| `path`    | `SVGPathElement` | The SVGPathElement to be used as the base path. |
+| Parameter | Type                                                                          | Description                                     |
+| --------- | ----------------------------------------------------------------------------- | ----------------------------------------------- |
+| `path`    | [`SVGPathElement`](https://developer.mozilla.org/docs/Web/API/SVGPathElement) | The SVGPathElement to be used as the base path. |
 
 ###### Returns
 
-`Promise`\<`void`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`>
 
 ###### Throws
 

--- a/api/utils/classnames.md
+++ b/api/utils/classnames.md
@@ -6,7 +6,7 @@
 
 # utils/classnames
 
-> Last updated 2024-08-20T06:28:48.132Z
+> Last updated 2024-08-20T06:35:08.858Z
 
 ## Functions
 
@@ -60,11 +60,11 @@ Remove CSS classes from an HTML element.
 
 #### Parameters
 
-| Parameter | Type          | Default value | Description                                            |
-| --------- | ------------- | ------------- | ------------------------------------------------------ |
-| `el`      | `HTMLElement` | `undefined`   | The HTML element from which classes should be removed. |
-| `cls`     | `string`      | `undefined`   | The CSS classes to remove, separated by spaces.        |
-| `avoid`?  | `string`      | `'noop'`      | Classes to avoid removing.                             |
+| Parameter | Type                                                                    | Default value | Description                                            |
+| --------- | ----------------------------------------------------------------------- | ------------- | ------------------------------------------------------ |
+| `el`      | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | `undefined`   | The HTML element from which classes should be removed. |
+| `cls`     | `string`                                                                | `undefined`   | The CSS classes to remove, separated by spaces.        |
+| `avoid`?  | `string`                                                                | `'noop'`      | Classes to avoid removing.                             |
 
 #### Returns
 
@@ -94,11 +94,11 @@ Add CSS classes to an HTML element.
 
 #### Parameters
 
-| Parameter | Type          | Default value | Description                                        |
-| --------- | ------------- | ------------- | -------------------------------------------------- |
-| `el`      | `HTMLElement` | `undefined`   | The HTML element to which classes should be added. |
-| `cls`     | `string`      | `undefined`   | The CSS classes to add, separated by spaces.       |
-| `avoid`?  | `string`      | `'noop'`      | Classes to avoid adding.                           |
+| Parameter | Type                                                                    | Default value | Description                                        |
+| --------- | ----------------------------------------------------------------------- | ------------- | -------------------------------------------------- |
+| `el`      | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | `undefined`   | The HTML element to which classes should be added. |
+| `cls`     | `string`                                                                | `undefined`   | The CSS classes to add, separated by spaces.       |
+| `avoid`?  | `string`                                                                | `'noop'`      | Classes to avoid adding.                           |
 
 #### Returns
 
@@ -128,11 +128,11 @@ Toggle CSS classes on an HTML element.
 
 #### Parameters
 
-| Parameter | Type          | Default value | Description                                          |
-| --------- | ------------- | ------------- | ---------------------------------------------------- |
-| `el`      | `HTMLElement` | `undefined`   | The HTML element on which classes should be toggled. |
-| `cls`     | `string`      | `undefined`   | The CSS classes to toggle, separated by spaces.      |
-| `avoid`?  | `string`      | `'noop'`      | Classes to avoid toggling.                           |
+| Parameter | Type                                                                    | Default value | Description                                          |
+| --------- | ----------------------------------------------------------------------- | ------------- | ---------------------------------------------------- |
+| `el`      | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | `undefined`   | The HTML element on which classes should be toggled. |
+| `cls`     | `string`                                                                | `undefined`   | The CSS classes to toggle, separated by spaces.      |
+| `avoid`?  | `string`                                                                | `'noop'`      | Classes to avoid toggling.                           |
 
 #### Returns
 

--- a/api/utils/constants.md
+++ b/api/utils/constants.md
@@ -6,7 +6,7 @@
 
 # utils/constants
 
-> Last updated 2024-08-20T06:28:48.132Z
+> Last updated 2024-08-20T06:35:08.859Z
 
 ## Variables
 

--- a/api/utils/coords.md
+++ b/api/utils/coords.md
@@ -6,7 +6,7 @@
 
 # utils/coords
 
-> Last updated 2024-08-20T06:28:48.133Z
+> Last updated 2024-08-20T06:35:08.859Z
 
 ## Variables
 

--- a/api/utils/css.md
+++ b/api/utils/css.md
@@ -6,7 +6,7 @@
 
 # utils/css
 
-> Last updated 2024-08-20T06:28:48.133Z
+> Last updated 2024-08-20T06:35:08.859Z
 
 ## Functions
 
@@ -162,9 +162,9 @@ Retrieves the value of a custom CSS property "--ph-speccer-line-width" from an e
 
 #### Parameters
 
-| Parameter | Type          | Description       |
-| --------- | ------------- | ----------------- |
-| `el`      | `HTMLElement` | The HTML element. |
+| Parameter | Type                                                                    | Description       |
+| --------- | ----------------------------------------------------------------------- | ----------------- |
+| `el`      | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The HTML element. |
 
 #### Returns
 
@@ -196,9 +196,9 @@ Retrieves the value of a custom CSS property "--ph-speccer-measure-size" from an
 
 #### Parameters
 
-| Parameter | Type          | Description       |
-| --------- | ------------- | ----------------- |
-| `el`      | `HTMLElement` | The HTML element. |
+| Parameter | Type                                                                    | Description       |
+| --------- | ----------------------------------------------------------------------- | ----------------- |
+| `el`      | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The HTML element. |
 
 #### Returns
 
@@ -265,9 +265,9 @@ Retrieves the value of a custom CSS property "--ph-speccer-pin-space" from an el
 
 #### Parameters
 
-| Parameter | Type          | Description       |
-| --------- | ------------- | ----------------- |
-| `el`      | `HTMLElement` | The HTML element. |
+| Parameter | Type                                                                    | Description       |
+| --------- | ----------------------------------------------------------------------- | ----------------- |
+| `el`      | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The HTML element. |
 
 #### Returns
 

--- a/api/utils/debounce.md
+++ b/api/utils/debounce.md
@@ -6,17 +6,14 @@
 
 # utils/debounce
 
-> Last updated 2024-08-20T06:28:48.134Z
+> Last updated 2024-08-20T06:35:08.860Z
 
 ## Functions
 
-### default()
+### debounce()
 
 ```ts
-function default(
-   func,
-   wait,
-   immediate?): DebounceAnyFunctionType
+function debounce(func, wait, immediate?): DebounceAnyFunctionType;
 ```
 
 Creates a debounced version of a function that delays its execution until after a specified waiting time has elapsed since the last time the debounced function was invoked.

--- a/api/utils/direction-of-element.md
+++ b/api/utils/direction-of-element.md
@@ -6,7 +6,7 @@
 
 # utils/direction-of-element
 
-> Last updated 2024-08-20T06:28:48.135Z
+> Last updated 2024-08-20T06:35:08.860Z
 
 ## Functions
 
@@ -20,16 +20,16 @@ Get the direction of an element based on its position relative to another elemen
 
 #### Parameters
 
-| Parameter        | Type          | Description                                           |
-| ---------------- | ------------- | ----------------------------------------------------- |
-| `options`        | `object`      | Options for direction calculation.                    |
-| `options.crude`? | `boolean`     | If the direction should be calculated crudely (NSEW). |
-| `options.start`  | `HTMLElement` | The starting HTML element.                            |
-| `options.stop`   | `HTMLElement` | The stopping HTML element.                            |
+| Parameter        | Type                                                                    | Description                                           |
+| ---------------- | ----------------------------------------------------------------------- | ----------------------------------------------------- |
+| `options`        | `object`                                                                | Options for direction calculation.                    |
+| `options.crude`? | `boolean`                                                               | If the direction should be calculated crudely (NSEW). |
+| `options.start`  | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The starting HTML element.                            |
+| `options.stop`   | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The stopping HTML element.                            |
 
 #### Returns
 
-`Promise`\<`string`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`string`>
 
 - The calculated direction.
 

--- a/api/utils/get-coords-pair-from-objects.md
+++ b/api/utils/get-coords-pair-from-objects.md
@@ -6,7 +6,7 @@
 
 # utils/get-coords-pair-from-objects
 
-> Last updated 2024-08-20T06:28:48.135Z
+> Last updated 2024-08-20T06:35:08.860Z
 
 ## Functions
 
@@ -30,16 +30,16 @@ Get the x and y coordinates of two elements and return them as an object.
 
 #### Parameters
 
-| Parameter | Type          | Default value | Description                                 |
-| --------- | ------------- | ------------- | ------------------------------------------- |
-| `el1`     | `HTMLElement` | `undefined`   | The first HTML element.                     |
-| `el2`     | `HTMLElement` | `undefined`   | The second HTML element.                    |
-| `pos1`?   | `string`      | `'center'`    | The position to use for the first element.  |
-| `pos2`?   | `string`      | `'center'`    | The position to use for the second element. |
+| Parameter | Type                                                                    | Default value | Description                                 |
+| --------- | ----------------------------------------------------------------------- | ------------- | ------------------------------------------- |
+| `el1`     | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | `undefined`   | The first HTML element.                     |
+| `el2`     | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | `undefined`   | The second HTML element.                    |
+| `pos1`?   | `string`                                                                | `'center'`    | The position to use for the first element.  |
+| `pos2`?   | `string`                                                                | `'center'`    | The position to use for the second element. |
 
 #### Returns
 
-`Promise`\<\{
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<\{
 `x1`: `number`;
 `x2`: `number`;
 `y1`: `number`;

--- a/api/utils/id.md
+++ b/api/utils/id.md
@@ -6,7 +6,7 @@
 
 # utils/id
 
-> Last updated 2024-08-20T06:28:48.135Z
+> Last updated 2024-08-20T06:35:08.860Z
 
 ## Functions
 

--- a/api/utils/intrinsic-coords.md
+++ b/api/utils/intrinsic-coords.md
@@ -6,7 +6,7 @@
 
 # utils/intrinsic-coords
 
-> Last updated 2024-08-20T06:28:48.135Z
+> Last updated 2024-08-20T06:35:08.860Z
 
 ## Functions
 
@@ -26,14 +26,14 @@ Get the intrinsic coordinates of an element based on a specified position.
 
 #### Parameters
 
-| Parameter | Type          | Default value | Description          |
-| --------- | ------------- | ------------- | -------------------- |
-| `el`      | `HTMLElement` | `undefined`   | The HTML element.    |
-| `pos`?    | `string`      | `'center'`    | The position to use. |
+| Parameter | Type                                                                    | Default value | Description          |
+| --------- | ----------------------------------------------------------------------- | ------------- | -------------------- |
+| `el`      | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | `undefined`   | The HTML element.    |
+| `pos`?    | `string`                                                                | `'center'`    | The position to use. |
 
 #### Returns
 
-`Promise`\<\{
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<\{
 `x`: `number`;
 `y`: `number`;
 }>

--- a/api/utils/node.md
+++ b/api/utils/node.md
@@ -6,7 +6,7 @@
 
 # utils/node
 
-> Last updated 2024-08-20T06:28:48.136Z
+> Last updated 2024-08-20T06:35:08.861Z
 
 ## Functions
 
@@ -20,14 +20,14 @@ Inserts an HTML element after another element in the DOM.
 
 #### Parameters
 
-| Parameter    | Type                    | Description                                                         |
-| ------------ | ----------------------- | ------------------------------------------------------------------- |
-| `el`         | `null` \| `HTMLElement` | The reference element after which the new element will be inserted. |
-| `newSibling` | `HTMLElement`           | The new element to be inserted.                                     |
+| Parameter    | Type                                                                              | Description                                                         |
+| ------------ | --------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `el`         | `null` \| [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The reference element after which the new element will be inserted. |
+| `newSibling` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement)           | The new element to be inserted.                                     |
 
 #### Returns
 
-`undefined` | `null` | `Element`
+`undefined` | `null` | [`Element`](https://developer.mozilla.org/docs/Web/API/Element)
 
 #### Example
 
@@ -53,9 +53,9 @@ Determines if an HTML element is hidden based on its visibility properties.
 
 #### Parameters
 
-| Parameter | Type          | Description                               |
-| --------- | ------------- | ----------------------------------------- |
-| `element` | `HTMLElement` | The HTML element to check for visibility. |
+| Parameter | Type                                                                    | Description                               |
+| --------- | ----------------------------------------------------------------------- | ----------------------------------------- |
+| `element` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The HTML element to check for visibility. |
 
 #### Returns
 
@@ -89,10 +89,10 @@ Removes all elements matching a selector from the DOM.
 
 #### Parameters
 
-| Parameter  | Type       | Default value | Description                                                     |
-| ---------- | ---------- | ------------- | --------------------------------------------------------------- |
-| `selector` | `string`   | `undefined`   | The CSS selector used to select elements for removal.           |
-| `el`       | `Document` | `document`    | The document context (default is the global `document` object). |
+| Parameter  | Type                                                              | Default value | Description                                                     |
+| ---------- | ----------------------------------------------------------------- | ------------- | --------------------------------------------------------------- |
+| `selector` | `string`                                                          | `undefined`   | The CSS selector used to select elements for removal.           |
+| `el`       | [`Document`](https://developer.mozilla.org/docs/Web/API/Document) | `document`    | The document context (default is the global `document` object). |
 
 #### Returns
 

--- a/api/utils/number.md
+++ b/api/utils/number.md
@@ -6,7 +6,7 @@
 
 # utils/number
 
-> Last updated 2024-08-20T06:28:48.136Z
+> Last updated 2024-08-20T06:35:08.861Z
 
 ## Functions
 

--- a/api/utils/position.md
+++ b/api/utils/position.md
@@ -6,7 +6,7 @@
 
 # utils/position
 
-> Last updated 2024-08-20T06:28:48.136Z
+> Last updated 2024-08-20T06:35:08.861Z
 
 ## Functions
 
@@ -20,14 +20,14 @@ Gets various positioning properties between two HTML elements.
 
 #### Parameters
 
-| Parameter  | Type          | Description              |
-| ---------- | ------------- | ------------------------ |
-| `sourceEl` | `HTMLElement` | The source HTML element. |
-| `targetEl` | `HTMLElement` | The target HTML element. |
+| Parameter  | Type                                                                    | Description              |
+| ---------- | ----------------------------------------------------------------------- | ------------------------ |
+| `sourceEl` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The source HTML element. |
+| `targetEl` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The target HTML element. |
 
 #### Returns
 
-`Promise`\<[`GetRecPropertiesInterface`](../types/interfaces/position.md#getrecpropertiesinterface)>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`GetRecPropertiesInterface`](../types/interfaces/position.md#getrecpropertiesinterface)>
 
 - A promise that resolves to an object with positioning functions.
 
@@ -60,11 +60,11 @@ Calculates the horizontal center of two elements.
 
 #### Parameters
 
-| Parameter    | Type      | Description                       |
-| ------------ | --------- | --------------------------------- |
-| `modifier`   | `number`  | A modifier value.                 |
-| `startRect`  | `DOMRect` | The starting element's rectangle. |
-| `targetRect` | `DOMRect` | The target element's rectangle.   |
+| Parameter    | Type                                                            | Description                       |
+| ------------ | --------------------------------------------------------------- | --------------------------------- |
+| `modifier`   | `number`                                                        | A modifier value.                 |
+| `startRect`  | [`DOMRect`](https://developer.mozilla.org/docs/Web/API/DOMRect) | The starting element's rectangle. |
+| `targetRect` | [`DOMRect`](https://developer.mozilla.org/docs/Web/API/DOMRect) | The target element's rectangle.   |
 
 #### Returns
 
@@ -95,11 +95,11 @@ Calculates the vertical center of two elements.
 
 #### Parameters
 
-| Parameter    | Type      | Description                       |
-| ------------ | --------- | --------------------------------- |
-| `modifier`   | `number`  | A modifier value.                 |
-| `startRect`  | `DOMRect` | The starting element's rectangle. |
-| `targetRect` | `DOMRect` | The target element's rectangle.   |
+| Parameter    | Type                                                            | Description                       |
+| ------------ | --------------------------------------------------------------- | --------------------------------- |
+| `modifier`   | `number`                                                        | A modifier value.                 |
+| `startRect`  | [`DOMRect`](https://developer.mozilla.org/docs/Web/API/DOMRect) | The starting element's rectangle. |
+| `targetRect` | [`DOMRect`](https://developer.mozilla.org/docs/Web/API/DOMRect) | The target element's rectangle.   |
 
 #### Returns
 
@@ -130,13 +130,13 @@ Gets the offset properties of an HTML element.
 
 #### Parameters
 
-| Parameter  | Type          | Description              |
-| ---------- | ------------- | ------------------------ |
-| `targetEl` | `HTMLElement` | The target HTML element. |
+| Parameter  | Type                                                                    | Description              |
+| ---------- | ----------------------------------------------------------------------- | ------------------------ |
+| `targetEl` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The target HTML element. |
 
 #### Returns
 
-`Promise`\<[`PositionPropertiesType`](../types/position.md#positionpropertiestype)>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`PositionPropertiesType`](../types/position.md#positionpropertiestype)>
 
 - A promise that resolves to the offset properties.
 
@@ -163,14 +163,14 @@ Gets the offset properties of an HTML element with its center aligned to another
 
 #### Parameters
 
-| Parameter  | Type          | Description              |
-| ---------- | ------------- | ------------------------ |
-| `sourceEl` | `HTMLElement` | The source HTML element. |
-| `targetEl` | `HTMLElement` | The target HTML element. |
+| Parameter  | Type                                                                    | Description              |
+| ---------- | ----------------------------------------------------------------------- | ------------------------ |
+| `sourceEl` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The source HTML element. |
+| `targetEl` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The target HTML element. |
 
 #### Returns
 
-`Promise`\<[`PositionPropertiesType`](../types/position.md#positionpropertiestype)>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`PositionPropertiesType`](../types/position.md#positionpropertiestype)>
 
 - A promise that resolves to the offset properties.
 

--- a/api/utils/resize.md
+++ b/api/utils/resize.md
@@ -6,7 +6,7 @@
 
 # utils/resize
 
-> Last updated 2024-08-20T06:28:48.137Z
+> Last updated 2024-08-20T06:35:08.861Z
 
 ## Functions
 

--- a/api/utils/style-property.md
+++ b/api/utils/style-property.md
@@ -6,7 +6,7 @@
 
 # utils/style-property
 
-> Last updated 2024-08-20T06:28:48.138Z
+> Last updated 2024-08-20T06:35:08.862Z
 
 ## Functions
 
@@ -20,13 +20,13 @@ Checks if an element has 'position: sticky'.
 
 #### Parameters
 
-| Parameter | Type          | Description         |
-| --------- | ------------- | ------------------- |
-| `element` | `HTMLElement` | The target element. |
+| Parameter | Type                                                                    | Description         |
+| --------- | ----------------------------------------------------------------------- | ------------------- |
+| `element` | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The target element. |
 
 #### Returns
 
-`Promise`\<`boolean`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`boolean`>
 
 - A promise that resolves to true if the element has 'position: sticky', false otherwise.
 

--- a/api/utils/styles.md
+++ b/api/utils/styles.md
@@ -6,7 +6,7 @@
 
 # utils/styles
 
-> Last updated 2024-08-20T06:28:48.138Z
+> Last updated 2024-08-20T06:35:08.862Z
 
 ## Functions
 
@@ -20,14 +20,14 @@ Adds CSS styles to an HTMLElement.
 
 #### Parameters
 
-| Parameter | Type                                                    | Description                                                      |
-| --------- | ------------------------------------------------------- | ---------------------------------------------------------------- |
-| `el`      | `HTMLElement`                                           | The HTMLElement to apply styles to.                              |
-| `styles`  | `object` \| \{ `key`: `string`; `value`: `string`; }\[] | An object or an array of objects containing CSS styles to apply. |
+| Parameter | Type                                                                    | Description                                                      |
+| --------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `el`      | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The HTMLElement to apply styles to.                              |
+| `styles`  | `object` \| \{ `key`: `string`; `value`: `string`; }\[]                 | An object or an array of objects containing CSS styles to apply. |
 
 #### Returns
 
-`Promise`\<`void`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`>
 
 - A Promise that resolves after styles are applied.
 
@@ -62,13 +62,13 @@ Gets the computed CSS styles of an HTMLElement.
 
 #### Parameters
 
-| Parameter | Type          | Description                                  |
-| --------- | ------------- | -------------------------------------------- |
-| `el`      | `HTMLElement` | The HTMLElement to get computed styles from. |
+| Parameter | Type                                                                    | Description                                  |
+| --------- | ----------------------------------------------------------------------- | -------------------------------------------- |
+| `el`      | [`HTMLElement`](https://developer.mozilla.org/docs/Web/API/HTMLElement) | The HTMLElement to get computed styles from. |
 
 #### Returns
 
-`Promise`\<`CSSStyleDeclaration`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`CSSStyleDeclaration`](https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration)>
 
 - A Promise that resolves with the computed CSS styles.
 

--- a/api/utils/typeof.md
+++ b/api/utils/typeof.md
@@ -6,7 +6,7 @@
 
 # utils/typeof
 
-> Last updated 2024-08-20T06:28:48.139Z
+> Last updated 2024-08-20T06:35:08.862Z
 
 ## Functions
 

--- a/api/utils/wait.md
+++ b/api/utils/wait.md
@@ -6,7 +6,7 @@
 
 # utils/wait
 
-> Last updated 2024-08-20T06:28:48.140Z
+> Last updated 2024-08-20T06:35:08.862Z
 
 ## Functions
 
@@ -26,7 +26,7 @@ Waits for the specified amount of time in milliseconds.
 
 #### Returns
 
-`Promise`\<`void`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`void`>
 
 - A Promise that resolves after the specified time.
 
@@ -53,7 +53,7 @@ Waits for the next animation frame using requestAnimationFrame.
 
 #### Returns
 
-`Promise`\<`number`>
+[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<`number`>
 
 - A Promise that resolves with the timestamp of the next animation frame.
 

--- a/api/utils/xy.md
+++ b/api/utils/xy.md
@@ -6,7 +6,7 @@
 
 # utils/xy
 
-> Last updated 2024-08-20T06:28:48.140Z
+> Last updated 2024-08-20T06:35:08.862Z
 
 ## Variables
 

--- a/src/features/pin/index.ts
+++ b/src/features/pin/index.ts
@@ -9,7 +9,7 @@
  * ```html
  * <div data-speccer="pin-area">
  *   <div
- *     data-speccer="pin [bracket|enclose][curly] [left|right|top|bottom]"
+ *     data-speccer="pin [bracket [curly] |enclose] [left|right|top|bottom]"
  *     class="..."
  *   ></div>
  * </div>

--- a/typedoc.json
+++ b/typedoc.json
@@ -3,6 +3,8 @@
   "plugin": [
     "typedoc-plugin-markdown",
     "typedoc-plugin-remark",
+    "typedoc-plugin-mdn-links",
+    "typedoc-plugin-rename-defaults",
     "./custom-typedoc-plugin.js"
   ],
   "out": "./api",


### PR DESCRIPTION
* docs: ✏️ Give correct order of `curly` feature in examples  - [29e8026](https://github.com/phun-ky/speccer/commit/29e8026)
* docs: ✏️ Regenerate API documentation  - [34cc5e9](https://github.com/phun-ky/speccer/commit/34cc5e9)
* docs: ✏️ Add missing typedoc plugin for mdn links  - [0f5b76e](https://github.com/phun-ky/speccer/commit/0f5b76e)
